### PR TITLE
Refactor to make it easier to add new secret engines

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-11.19
+resolver: lts-18.10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/vault-tool-server/src/Network/VaultTool/VaultServerProcess.hs
+++ b/vault-tool-server/src/Network/VaultTool/VaultServerProcess.hs
@@ -220,7 +220,7 @@ shutdownVaultServerProcess vs = do
 
 vaultIsRunning :: VaultAddress -> IO Bool
 vaultIsRunning addr = do
-    conn <- flip UnauthenticatedVaultConnection addr <$> defaultManager
+    conn <- flip unauthenticatedVaultConnection addr <$> defaultManager
     (vaultHealth conn >> pure True) `catches`
         [ Handler $ \(_ :: HttpException) -> pure False
         , Handler $ \(_ :: VaultException) -> pure False

--- a/vault-tool-server/src/Network/VaultTool/VaultServerProcess.hs
+++ b/vault-tool-server/src/Network/VaultTool/VaultServerProcess.hs
@@ -3,56 +3,57 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Network.VaultTool.VaultServerProcess (
-    VaultServerProcess,
-    launchVaultServerProcess,
-    shutdownVaultServerProcess,
-    withVaultServerProcess,
-    VaultBackendConfig,
-    withVaultConfigFile,
-    vaultConfigDefaultAddress,
-    vaultAddress,
-    readVaultBackendConfig,
-    readVaultUnsealKeys,
-) where
+module Network.VaultTool.VaultServerProcess
+    ( VaultServerProcess
+    , launchVaultServerProcess
+    , shutdownVaultServerProcess
+    , withVaultServerProcess
+
+    , VaultBackendConfig
+    , withVaultConfigFile
+    , vaultConfigDefaultAddress
+    , vaultAddress
+
+    , readVaultBackendConfig
+    , readVaultUnsealKeys
+    ) where
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
-import Control.Exception (Exception, Handler (Handler), IOException, bracket, bracketOnError, catches, throwIO, try)
+import Control.Exception (Exception, IOException, catches, Handler(Handler), bracket, bracketOnError, throwIO, try)
 import Control.Monad (forever)
 import Data.Aeson
-import qualified Data.ByteString.Lazy as BL
 import Data.Functor ((<&>))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import Network.HTTP.Client (HttpException)
 import System.Exit (ExitCode)
 import System.FilePath ((</>))
 import System.IO (Handle, hClose)
 import System.IO.Temp
 import System.Process
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
 
 import Network.VaultTool
 
-{- | The ""backend"" section of the Vault server configuration.
-
- See <https://www.vaultproject.io/docs/config/index.html>
-
- > {
- >   "consul": {
- >     "address": "127.0.0.1:8500",
- >     "path": "vault"
- >   }
- > }
-
- > {
- >   "file": {
- >     "path": "vault-storage"
- >   }
- > }
--}
+-- | The ""backend"" section of the Vault server configuration.
+--
+-- See <https://www.vaultproject.io/docs/config/index.html>
+--
+-- > {
+-- >   "consul": {
+-- >     "address": "127.0.0.1:8500",
+-- >     "path": "vault"
+-- >   }
+-- > }
+--
+-- > {
+-- >   "file": {
+-- >     "path": "vault-storage"
+-- >   }
+-- > }
 type VaultBackendConfig = Value
 
 data VaultConfig = VaultConfig
@@ -62,19 +63,16 @@ data VaultConfig = VaultConfig
     deriving (Show)
 
 instance ToJSON VaultConfig where
-    toJSON VaultConfig{..} =
-        object
-            [ "backend" .= _VaultConfig_Backend
-            , "listener"
-                .= object
-                    [ "tcp"
-                        .= object
-                            [ "tls_disable" .= T.pack "true"
-                            , "address" .= _VaultConfig_ListenAddress
-                            ]
-                    ]
-            , "disable_mlock" .= True
+    toJSON VaultConfig{..} = object
+        [ "backend" .= _VaultConfig_Backend
+        , "listener" .= object
+            [ "tcp" .= object
+                [ "tls_disable" .= T.pack "true"
+                , "address" .= _VaultConfig_ListenAddress
+                ]
             ]
+        , "disable_mlock" .= True
+        ]
 
 vaultConfigDefaultAddress :: VaultBackendConfig -> VaultConfig
 vaultConfigDefaultAddress b =
@@ -82,15 +80,14 @@ vaultConfigDefaultAddress b =
         { _VaultConfig_Backend = b
         , _VaultConfig_ListenAddress = defaultAddress
         }
-  where
+    where
     defaultAddress = "127.0.0.1:8200"
 
-{- | Get the address that can be used to connect to a running Vault server
- launched with the specified config.
-
- The returned value will begin with ""http://"" or ""https://"" (depending on
- the config)
--}
+-- | Get the address that can be used to connect to a running Vault server
+-- launched with the specified config.
+--
+-- The returned value will begin with ""http://"" or ""https://"" (depending on
+-- the config)
 vaultAddress :: VaultConfig -> VaultAddress
 vaultAddress VaultConfig{_VaultConfig_ListenAddress} =
     VaultAddress ("http://" `T.append` _VaultConfig_ListenAddress)
@@ -132,8 +129,7 @@ instance Exception VaultServerLaunchException
 
 withVaultServerProcess :: Maybe FilePath -> FilePath -> VaultAddress -> IO a -> IO a
 withVaultServerProcess mbVaultExe vaultConfigFile addr act = do
-    bracket
-        (launchVaultServerProcess mbVaultExe vaultConfigFile addr)
+    bracket (launchVaultServerProcess mbVaultExe vaultConfigFile addr)
         shutdownVaultServerProcess
         (const act)
 
@@ -147,7 +143,7 @@ launchVaultServerProcess mbVaultExe vaultConfigFile addr = do
                 withAsync (checkProcessFailureThread vs) $ \startupErrorA -> do
                     _ <- waitAnyCancel [waitUntilRunningA, startupErrorA]
                     pure vs
-  where
+    where
     vaultExe = fromMaybe "vault" mbVaultExe
     waitUntilRunningThread stdoutH = do
         withAsync (waitUntilVaultStarted stdoutH) $ \startA -> do
@@ -196,26 +192,22 @@ launchVaultServerProcess mbVaultExe vaultConfigFile addr = do
 
 execProcess :: FilePath -> FilePath -> IO VaultServerProcess
 execProcess vaultExe vaultConfigFile = do
-    tryResult <-
-        try $
-            createProcess $
-                (proc vaultExe ["server", "-config=" ++ vaultConfigFile])
-                    { env = Just []
-                    , std_in = CreatePipe
-                    , std_out = CreatePipe
-                    , std_err = CreatePipe
-                    , close_fds = True
-                    }
+    tryResult <- try $ createProcess $ (proc vaultExe ["server", "-config=" ++ vaultConfigFile])
+                                            { env = Just []
+                                            , std_in = CreatePipe
+                                            , std_out = CreatePipe
+                                            , std_err = CreatePipe
+                                            , close_fds = True
+                                            }
     case tryResult of
         Left ex -> throwIO $ VaultServerLaunchException_ExecFailure ex
         Right (Just stdinH, Just stdoutH, Just stderrH, processHandle) ->
-            pure
-                VaultServerProcess
-                    { vs_processHandle = processHandle
-                    , vs_stdinH = stdinH
-                    , vs_stdoutH = stdoutH
-                    , vs_stderrH = stderrH
-                    }
+            pure VaultServerProcess
+                { vs_processHandle = processHandle
+                , vs_stdinH = stdinH
+                , vs_stdoutH = stdoutH
+                , vs_stderrH = stderrH
+                }
         Right _ -> error "execProcess: The Impossible Happened"
 
 shutdownVaultServerProcess :: VaultServerProcess -> IO ()
@@ -229,7 +221,7 @@ shutdownVaultServerProcess vs = do
 
 vaultIsRunning :: VaultAddress -> IO Bool
 vaultIsRunning addr = do
-    (vaultHealth addr >> pure True)
-        `catches` [ Handler $ \(_ :: HttpException) -> pure False
-                  , Handler $ \(_ :: VaultException) -> pure False
-                  ]
+    (vaultHealth addr >> pure True) `catches`
+        [ Handler $ \(_ :: HttpException) -> pure False
+        , Handler $ \(_ :: VaultException) -> pure False
+        ]

--- a/vault-tool-server/src/Network/VaultTool/VaultServerProcess.hs
+++ b/vault-tool-server/src/Network/VaultTool/VaultServerProcess.hs
@@ -23,7 +23,6 @@ import Control.Concurrent.Async
 import Control.Exception (Exception, IOException, catches, Handler(Handler), bracket, bracketOnError, throwIO, try)
 import Control.Monad (forever)
 import Data.Aeson
-import Data.Functor ((<&>))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Network.HTTP.Client (HttpException)
@@ -102,7 +101,7 @@ readVaultBackendConfig file = do
 -- | File should have one line per key (blank lines are ignored)
 readVaultUnsealKeys :: FilePath -> IO [VaultUnsealKey]
 readVaultUnsealKeys file =
-    T.readFile file <&> (map VaultUnsealKey . filter (not . T.null) . map T.strip . T.lines)
+    map VaultUnsealKey . filter (not . T.null) . map T.strip . T.lines <$> T.readFile file
 
 withVaultConfigFile :: VaultConfig -> (FilePath -> IO a) -> IO a
 withVaultConfigFile vaultConfig action = do

--- a/vault-tool-server/src/Network/VaultTool/VaultServerProcess.hs
+++ b/vault-tool-server/src/Network/VaultTool/VaultServerProcess.hs
@@ -220,7 +220,8 @@ shutdownVaultServerProcess vs = do
 
 vaultIsRunning :: VaultAddress -> IO Bool
 vaultIsRunning addr = do
-    (vaultHealth addr >> pure True) `catches`
+    conn <- flip UnauthenticatedVaultConnection addr <$> defaultManager
+    (vaultHealth conn >> pure True) `catches`
         [ Handler $ \(_ :: HttpException) -> pure False
         , Handler $ \(_ :: VaultException) -> pure False
         ]

--- a/vault-tool-server/test/test.hs
+++ b/vault-tool-server/test/test.hs
@@ -16,7 +16,13 @@ import Test.Tasty.HUnit
 
 import Network.VaultTool
 import Network.VaultTool.KeyValueV2
-import Network.VaultTool.VaultServerProcess
+import Network.VaultTool.VaultServerProcess (
+    VaultBackendConfig,
+    vaultAddress,
+    vaultConfigDefaultAddress,
+    withVaultConfigFile,
+    withVaultServerProcess,
+ )
 
 withTempVaultBackend :: (VaultBackendConfig -> IO a) -> IO a
 withTempVaultBackend action = withSystemTempDirectory "hs_vault" $ \tmpDir -> do
@@ -49,7 +55,7 @@ talkToVault :: VaultAddress -> IO ()
 talkToVault addr = do
     manager <- defaultManager
 
-    let unauthConn = UnauthenticatedVaultConnection manager addr
+    let unauthConn = unauthenticatedVaultConnection manager addr
 
     health <- vaultHealth unauthConn
     _VaultHealth_Initialized health @?= False
@@ -98,7 +104,7 @@ talkToVault addr = do
         , _VaultSealStatus_Progress = 0
         }
 
-    let authConn = AuthenticatedVaultConnection manager addr rootToken
+    let authConn = authenticatedVaultConnection manager addr rootToken
 
     vaultNewMount authConn "secret" VaultMount
         { _VaultMount_Type = "kv"

--- a/vault-tool-server/test/test.hs
+++ b/vault-tool-server/test/test.hs
@@ -53,6 +53,7 @@ import Network.VaultTool.KeyValueV2 (
     VaultSecretVersion (..),
     vaultDelete,
     vaultRead,
+    vaultReadVersion,
     vaultWrite,
     vaultList,
     vaultListRecursive,
@@ -232,6 +233,14 @@ talkToVault addr = do
         , pathFooQuackDuck
         ]
 
+    let pathReadVersionTest = mkVaultSecretPath "read/version/secret"
+    vaultWrite authConn pathReadVersionTest (FunStuff "x" [1])
+    vaultWrite authConn pathReadVersionTest (FunStuff "y" [2, 3])
+    v1Resp <- vaultReadVersion authConn pathReadVersionTest (Just 1)
+    vsvData v1Resp @?= (FunStuff "x" [1])
+    v2Resp <- vaultReadVersion authConn pathReadVersionTest Nothing
+    vsvData v2Resp @?= (FunStuff "y" [2, 3])
+
     vaultAuthEnable authConn "approle"
 
     let pathSmall = mkVaultSecretPath "small"
@@ -260,8 +269,6 @@ talkToVault addr = do
     health2 <- vaultHealth unauthConn
     _VaultHealth_Initialized health2 @?= True
     _VaultHealth_Sealed health2 @?= True
-
-    -- TODO add test for vaultReadVersion
 
 data FunStuff = FunStuff
     { funString :: String

--- a/vault-tool-server/test/test.hs
+++ b/vault-tool-server/test/test.hs
@@ -5,17 +5,58 @@
 module Main where
 
 import Control.Exception (catch)
-import Data.Aeson
+import Data.Aeson (FromJSON, ToJSON, (.=), object)
 import Data.Functor (($>))
 import Data.List (sort)
 import Data.Text (Text)
-import GHC.Generics
-import System.Environment
+import GHC.Generics (Generic)
+import System.Environment (lookupEnv)
 import System.IO.Temp (withSystemTempDirectory)
-import Test.Tasty.HUnit
+import Test.Tasty.HUnit ((@?=), assertBool)
 
-import Network.VaultTool
-import Network.VaultTool.KeyValueV2
+import Network.VaultTool (
+    VaultAddress,
+    VaultAppRoleParameters (..),
+    VaultAppRoleSecretIdGenerateResponse (..),
+    VaultException,
+    VaultHealth (..),
+    VaultMount (..),
+    VaultMountConfig (..),
+    VaultMountOptions (..),
+    VaultMountedPath (..),
+    VaultSealStatus (..),
+    VaultSearchPath (..),
+    VaultSecretPath (..),
+    VaultUnseal (..),
+    authenticatedVaultConnection,
+    connectToVaultAppRole,
+    defaultManager,
+    defaultVaultAppRoleParameters,
+    unauthenticatedVaultConnection,
+    vaultAppRoleCreate,
+    vaultAppRoleRoleIdRead,
+    vaultAppRoleSecretIdGenerate,
+    vaultAuthEnable,
+    vaultHealth,
+    vaultInit,
+    vaultMountSetTune,
+    vaultMountTune,
+    vaultMounts,
+    vaultNewMount,
+    vaultPolicyCreate,
+    vaultSeal,
+    vaultSealStatus,
+    vaultUnmount,
+    vaultUnseal,
+ )
+import Network.VaultTool.KeyValueV2 (
+    VaultSecretVersion (..),
+    vaultDelete,
+    vaultRead,
+    vaultWrite,
+    vaultList,
+    vaultListRecursive,
+ )
 import Network.VaultTool.VaultServerProcess (
     VaultBackendConfig,
     vaultAddress,
@@ -219,6 +260,8 @@ talkToVault addr = do
     health2 <- vaultHealth unauthConn
     _VaultHealth_Initialized health2 @?= True
     _VaultHealth_Sealed health2 @?= True
+
+    -- TODO add test for vaultReadVersion
 
 data FunStuff = FunStuff
     { funString :: String

--- a/vault-tool-server/vault-tool-server.cabal
+++ b/vault-tool-server/vault-tool-server.cabal
@@ -41,9 +41,10 @@ test-suite test
   hs-source-dirs:      test
   main-is:             test.hs
 
-  build-depends:       base >=4.8 && <4.11,
+  build-depends:       base >=4.8 && <5,
                        vault-tool >=0.1.0.1,
                        vault-tool-server,
                        aeson,
                        tasty-hunit,
-                       temporary
+                       temporary,
+                       text

--- a/vault-tool-server/vault-tool-server.cabal
+++ b/vault-tool-server/vault-tool-server.cabal
@@ -1,5 +1,5 @@
 name:                vault-tool-server
-version:             0.1.0.1
+version:             0.2.0.0
 synopsis:            Utility library for spawning a HashiCorp Vault process
 description:         Utility library for spawning a HashiCorp Vault process
 license:             MIT
@@ -22,7 +22,7 @@ library
   exposed-modules:     Network.VaultTool.VaultServerProcess
 
   build-depends:       base >=4.8 && < 5,
-                       vault-tool >=0.1.0.1,
+                       vault-tool >=0.2.0.0,
                        aeson,
                        async,
                        bytestring,
@@ -42,7 +42,7 @@ test-suite test
   main-is:             test.hs
 
   build-depends:       base >=4.8 && <5,
-                       vault-tool >=0.1.0.1,
+                       vault-tool >=0.2.0.0,
                        vault-tool-server,
                        aeson,
                        tasty-hunit,

--- a/vault-tool-server/vault-tool-server.cabal
+++ b/vault-tool-server/vault-tool-server.cabal
@@ -1,5 +1,5 @@
 name:                vault-tool-server
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Utility library for spawning a HashiCorp Vault process
 description:         Utility library for spawning a HashiCorp Vault process
 license:             MIT
@@ -22,7 +22,7 @@ library
   exposed-modules:     Network.VaultTool.VaultServerProcess
 
   build-depends:       base >=4.8 && < 5,
-                       vault-tool >=0.1.0.0,
+                       vault-tool >=0.1.0.1,
                        aeson,
                        async,
                        bytestring,
@@ -42,7 +42,7 @@ test-suite test
   main-is:             test.hs
 
   build-depends:       base >=4.8 && <4.11,
-                       vault-tool >=0.1.0.0,
+                       vault-tool >=0.1.0.1,
                        vault-tool-server,
                        aeson,
                        tasty-hunit,

--- a/vault-tool/src/Network/VaultTool.hs
+++ b/vault-tool/src/Network/VaultTool.hs
@@ -13,7 +13,12 @@ module Network.VaultTool
     , VaultAppRoleSecretId(..)
     , VaultException(..)
 
+    , VaultConnection
+    , Unauthenticated
+    , Authenticated
     , defaultManager
+    , authenticatedVaultConnection
+    , unauthenticatedVaultConnection
 
     , VaultHealth(..)
     , vaultHealth
@@ -52,7 +57,6 @@ module Network.VaultTool
     , vaultNewMount
     , vaultUnmount
 
-    , VaultConnection (..)
     , VaultMountedPath(..)
     , VaultSearchPath(..)
     , VaultSecretPath(..)
@@ -107,8 +111,8 @@ defaultManager = newManager tlsManagerSettings
 -- and then calls `connectToVault`
 connectToVaultAppRole :: Manager -> VaultAddress -> VaultAppRoleId -> VaultAppRoleSecretId -> IO (VaultConnection Authenticated)
 connectToVaultAppRole manager addr roleId secretId =
-    AuthenticatedVaultConnection manager addr <$>
-        vaultAppRoleLogin (UnauthenticatedVaultConnection manager addr) roleId secretId
+    authenticatedVaultConnection manager addr <$>
+        vaultAppRoleLogin (unauthenticatedVaultConnection manager addr) roleId secretId
 
 -- | <https://www.vaultproject.io/docs/http/sys-init.html>
 --

--- a/vault-tool/src/Network/VaultTool.hs
+++ b/vault-tool/src/Network/VaultTool.hs
@@ -2,120 +2,70 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Unless otherwise specified, all IO functions in this module may
--- potentially throw 'HttpException' or 'VaultException'
+{- | Unless otherwise specified, all IO functions in this module may
+ potentially throw 'HttpException' or 'VaultException'
+-}
+module Network.VaultTool (
+    VaultAddress (..),
+    VaultUnsealKey (..),
+    VaultAuthToken (..),
+    VaultAppRoleId (..),
+    VaultAppRoleSecretId (..),
+    VaultException (..),
+    VaultHealth (..),
+    vaultHealth,
+    connectToVault,
+    connectToVaultAppRole,
+    vaultAuthEnable,
+    vaultPolicyCreate,
+    vaultInit,
+    VaultSealStatus (..),
+    vaultSealStatus,
+    vaultSeal,
+    VaultUnseal (..),
+    vaultUnseal,
+    vaultAppRoleCreate,
+    vaultAppRoleRoleIdRead,
+    vaultAppRoleSecretIdGenerate,
+    defaultVaultAppRoleParameters,
+    VaultAppRoleParameters (..),
+    VaultAppRoleSecretIdGenerateResponse (..),
+    VaultMount (..),
+    VaultMountRead,
+    VaultMountWrite,
+    VaultMountConfig (..),
+    VaultMountConfigRead,
+    VaultMountConfigWrite,
+    VaultMountOptions (..),
+    VaultMountConfigOptions,
+    vaultMounts,
+    vaultMountTune,
+    vaultMountSetTune,
+    vaultNewMount,
+    vaultUnmount,
+    VaultMountedPath (..),
+    VaultSearchPath (..),
+    VaultSecretPath (..),
+) where
 
-module Network.VaultTool
-    ( VaultAddress(..)
-    , VaultUnsealKey(..)
-    , VaultAuthToken(..)
-    , VaultAppRoleId(..)
-    , VaultAppRoleSecretId(..)
-    , VaultException(..)
-
-    , VaultHealth(..)
-    , vaultHealth
-
-    , VaultConnection
-    , connectToVault
-
-    , connectToVaultAppRole
-
-    , vaultAuthEnable
-
-    , vaultPolicyCreate
-
-    , vaultInit
-    , VaultSealStatus(..)
-    , vaultSealStatus
-    , vaultSeal
-    , VaultUnseal(..)
-    , vaultUnseal
-
-    , vaultAppRoleCreate
-    , vaultAppRoleRoleIdRead
-    , vaultAppRoleSecretIdGenerate
-    , defaultVaultAppRoleParameters
-    , VaultAppRoleParameters(..)
-    , VaultAppRoleSecretIdGenerateResponse(..)
-
-    , VaultMount(..)
-    , VaultMountRead
-    , VaultMountWrite
-    , VaultMountConfig(..)
-    , VaultMountConfigRead
-    , VaultMountConfigWrite
-    , vaultMounts
-    , vaultMountTune
-    , vaultMountSetTune
-    , vaultNewMount
-    , vaultUnmount
-
-    , VaultMountedPath(..)
-    , VaultSearchPath(..)
-    , VaultSecretPath(..)
-    , VaultSecretMetadata(..)
-    , vaultWrite
-    , vaultRead
-    , vaultDelete
-    , vaultList
-    , isFolder
-    , vaultListRecursive
-    ) where
-
-import Data.Monoid ((<>))
 import Control.Exception (throwIO)
-import Control.Monad (liftM)
 import Data.Aeson
-import Data.Aeson.Types (parseEither, Pair)
+import Data.Aeson.Types (Pair, parseEither)
+import qualified Data.HashMap.Strict as H
 import Data.List (sortOn)
-import Data.Text (Text)
 import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import qualified Data.Text as T
 import Network.HTTP.Client (Manager, newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
-import Network.HTTP.Types.Header (Header)
-import qualified Data.HashMap.Strict as H
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 
 import Network.VaultTool.Internal
 import Network.VaultTool.Types
 
-data VaultAction
-    = Create
-    | ReadVersion
-    | ReadMetadata
-    | Update
-    | UpdateMetadata
-    | ListSecrets
-    | DeleteLast
-    | DeleteVersions
-    | Undelete
-    | Destroy
-    | DeleteMetadata
+{- | <https://www.vaultproject.io/docs/http/sys-health.html>
 
-vaultUrlPrefix :: VaultAction -> String
-vaultUrlPrefix Create         = "/data"
-vaultUrlPrefix ReadVersion    = "/data"
-vaultUrlPrefix Update         = "/data"
-vaultUrlPrefix DeleteLast     = "/data"
-vaultUrlPrefix DeleteVersions = "/delete"
-vaultUrlPrefix Undelete       = "/undelete"
-vaultUrlPrefix Destroy        = "/destroy"
-vaultUrlPrefix ListSecrets    = "/metadata"
-vaultUrlPrefix ReadMetadata   = "/metadata"
-vaultUrlPrefix UpdateMetadata = "/metadata"
-vaultUrlPrefix DeleteMetadata = "/metadata"
-
-data VaultConnection = VaultConnection
-    { _VaultConnection_AuthToken :: VaultAuthToken
-    , _VaultConnection_VaultAddress :: VaultAddress
-    , _VaultConnection_Manager :: Manager
-    }
-
--- | <https://www.vaultproject.io/docs/http/sys-health.html>
---
--- See 'vaultHealth'
+ See 'vaultHealth'
+-}
 data VaultHealth = VaultHealth
     { _VaultHealth_Version :: Text
     , _VaultHealth_ServerTimeUtc :: Int
@@ -127,52 +77,46 @@ data VaultHealth = VaultHealth
 
 instance FromJSON VaultHealth where
     parseJSON (Object v) =
-        VaultHealth <$>
-             v .: "version" <*>
-             v .: "server_time_utc" <*>
-             v .: "initialized" <*>
-             v .: "sealed" <*>
-             v .: "standby"
+        VaultHealth
+            <$> v .: "version"
+            <*> v .: "server_time_utc"
+            <*> v .: "initialized"
+            <*> v .: "sealed"
+            <*> v .: "standby"
     parseJSON _ = fail "Not an Object"
-
-vaultUrl :: VaultAddress -> String -> String
-vaultUrl (VaultAddress addr) path = T.unpack addr ++ "/v1" ++ path
-
-vaultActionUrl :: VaultAction -> VaultAddress -> VaultMountedPath -> VaultSearchPath -> String
-vaultActionUrl action (VaultAddress addr) (VaultMountedPath mountedPath) (VaultSearchPath searchPath) =
-    T.unpack addr ++ "/v1/"  ++ T.unpack mountedPath ++ (vaultUrlPrefix action) ++ "/" ++ T.unpack searchPath
 
 -- | https://www.vaultproject.io/docs/http/sys-health.html
 vaultHealth :: VaultAddress -> IO VaultHealth
-vaultHealth vaultAddress = do
+vaultHealth addr = do
     manager <- newManager tlsManagerSettings
-    vaultRequestJSON manager "GET" (vaultUrl vaultAddress "/sys/health") [] (Nothing :: Maybe ()) expectedStatusCodes
-    where
+    runVaultRequest (mkUnauthenticatedVaultConnection addr manager)
+        . withStatusCodes expectedStatusCodes
+        $ newGetRequest "/sys/health"
+  where
     expectedStatusCodes = [200, 429, 501, 503]
 
--- | Just initializes the 'VaultConnection' objects, does not actually make any
--- contact with the vault server. (That is also the explanation why there is no
--- function to disconnect)
+{- | Just initializes the 'VaultConnection' objects, does not actually make any
+ contact with the vault server. (That is also the explanation why there is no
+ function to disconnect)
+-}
 connectToVault :: VaultAddress -> VaultAuthToken -> IO VaultConnection
 connectToVault addr authToken = do
     manager <- newManager tlsManagerSettings
-    pure VaultConnection
-            { _VaultConnection_AuthToken = authToken
-            , _VaultConnection_VaultAddress = addr
-            , _VaultConnection_Manager = manager
-            }
+    pure $ mkAuthenticatedVaultConnection addr manager authToken
 
--- | Initializes the 'VaultConnection' objects using approle credentials to retrieve an authtoken,
--- and then calls `connectToVault`
+{- | Initializes the 'VaultConnection' objects using approle credentials to retrieve an authtoken,
+ and then calls `connectToVault`
+-}
 connectToVaultAppRole :: VaultAddress -> VaultAppRoleId -> VaultAppRoleSecretId -> IO VaultConnection
 connectToVaultAppRole addr roleId secretId = do
     manager <- newManager tlsManagerSettings
     authToken <- vaultAppRoleLogin addr manager roleId secretId
     connectToVault addr authToken
 
--- | <https://www.vaultproject.io/docs/http/sys-init.html>
---
--- See 'vaultInit'
+{- | <https://www.vaultproject.io/docs/http/sys-init.html>
+
+ See 'vaultInit'
+-}
 data VaultInitResponse = VaultInitResponse
     { _VaultInitResponse_Keys :: [Text]
     , _VaultInitResponse_RootToken :: VaultAuthToken
@@ -181,58 +125,70 @@ data VaultInitResponse = VaultInitResponse
 
 instance FromJSON VaultInitResponse where
     parseJSON (Object v) =
-        VaultInitResponse <$>
-             v .: "keys" <*>
-             v .: "root_token"
+        VaultInitResponse
+            <$> v .: "keys"
+            <*> v .: "root_token"
     parseJSON _ = fail "Not an Object"
 
 -- | <https://www.vaultproject.io/docs/http/sys-init.html>
-vaultInit
-    :: VaultAddress
-    -> Int -- ^ @secret_shares@: The number of shares to split the master key
-           -- into
-    -> Int -- ^ @secret_threshold@: The number of shares required to
-           -- reconstruct the master key. This must be less than or equal to
-           -- secret_shares
-    -> IO ([VaultUnsealKey], VaultAuthToken) -- ^ master keys and initial root token
+vaultInit ::
+    VaultAddress ->
+    -- | @secret_shares@: The number of shares to split the master key
+    -- into
+    Int ->
+    -- | @secret_threshold@: The number of shares required to
+    -- reconstruct the master key. This must be less than or equal to
+    -- secret_shares
+    Int ->
+    -- | master keys and initial root token
+    IO ([VaultUnsealKey], VaultAuthToken)
 vaultInit addr secretShares secretThreshold = do
-    let reqBody = object
-            [ "secret_shares" .= secretShares
-            , "secret_threshold" .= secretThreshold
-            ]
+    let reqBody =
+            object
+                [ "secret_shares" .= secretShares
+                , "secret_threshold" .= secretThreshold
+                ]
     manager <- newManager tlsManagerSettings
-    rsp <- vaultRequestJSON manager "PUT" (vaultUrl addr "/sys/init") [] (Just reqBody) [200]
+    rsp <-
+        runVaultRequest (mkUnauthenticatedVaultConnection addr manager) $
+            newPutRequest "/sys/init" (Just reqBody)
     let VaultInitResponse{_VaultInitResponse_Keys, _VaultInitResponse_RootToken} = rsp
     pure (map VaultUnsealKey _VaultInitResponse_Keys, _VaultInitResponse_RootToken)
 
--- | <https://www.vaultproject.io/docs/http/sys-seal-status.html>
---
--- See 'vaultSealStatus'
+{- | <https://www.vaultproject.io/docs/http/sys-seal-status.html>
+
+ See 'vaultSealStatus'
+-}
 data VaultSealStatus = VaultSealStatus
     { _VaultSealStatus_Sealed :: Bool
-    , _VaultSealStatus_T :: Int -- ^ threshold
-    , _VaultSealStatus_N :: Int -- ^ number of shares
+    , -- | threshold
+      _VaultSealStatus_T :: Int
+    , -- | number of shares
+      _VaultSealStatus_N :: Int
     , _VaultSealStatus_Progress :: Int
     }
     deriving (Show, Eq, Ord)
 
 instance FromJSON VaultSealStatus where
     parseJSON (Object v) =
-        VaultSealStatus <$>
-             v .: "sealed" <*>
-             v .: "t" <*>
-             v .: "n" <*>
-             v .: "progress"
+        VaultSealStatus
+            <$> v .: "sealed"
+            <*> v .: "t"
+            <*> v .: "n"
+            <*> v .: "progress"
     parseJSON _ = fail "Not an Object"
 
 vaultSealStatus :: VaultAddress -> IO VaultSealStatus
 vaultSealStatus addr = do
     manager <- newManager tlsManagerSettings
-    vaultRequestJSON manager "GET" (vaultUrl addr "/sys/seal-status") [] (Nothing :: Maybe ()) [200]
+    runVaultRequest
+        (mkUnauthenticatedVaultConnection addr manager)
+        (newGetRequest "/sys/seal-status")
 
--- | <https://www.vaultproject.io/api/auth/approle/index.html>
---
--- See 'sample-response-7'
+{- | <https://www.vaultproject.io/api/auth/approle/index.html>
+
+ See 'sample-response-7'
+-}
 data VaultAuth = VaultAuth
     { _VaultAuth_Renewable :: Bool
     , _VaultAuth_LeaseDuration :: Int
@@ -243,16 +199,17 @@ data VaultAuth = VaultAuth
 
 instance FromJSON VaultAuth where
     parseJSON (Object v) =
-        VaultAuth <$>
-            v .: "renewable" <*>
-            v .: "lease_duration" <*>
-            v .: "policies" <*>
-            v .: "client_token"
+        VaultAuth
+            <$> v .: "renewable"
+            <*> v .: "lease_duration"
+            <*> v .: "policies"
+            <*> v .: "client_token"
     parseJSON _ = fail "Not an Object"
 
--- | <https://www.vaultproject.io/api/auth/approle/index.html>
---
--- See 'sample-response-7'
+{- | <https://www.vaultproject.io/api/auth/approle/index.html>
+
+ See 'sample-response-7'
+-}
 data VaultAppRoleResponse = VaultAppRoleResponse
     { _VaultAppRoleResponse_Auth :: Maybe VaultAuth
     , _VaultAppRoleResponse_Warnings :: Value
@@ -266,61 +223,68 @@ data VaultAppRoleResponse = VaultAppRoleResponse
 
 instance FromJSON VaultAppRoleResponse where
     parseJSON (Object v) =
-        VaultAppRoleResponse <$>
-            v .:? "auth" <*>
-            v .: "warnings" <*>
-            v .: "wrap_info" <*>
-            v .: "data" <*>
-            v .: "lease_duration" <*>
-            v .: "renewable" <*>
-            v .: "lease_id"
+        VaultAppRoleResponse
+            <$> v .:? "auth"
+            <*> v .: "warnings"
+            <*> v .: "wrap_info"
+            <*> v .: "data"
+            <*> v .: "lease_duration"
+            <*> v .: "renewable"
+            <*> v .: "lease_id"
     parseJSON _ = fail "Not an Object"
-
-authTokenHeader :: VaultAuthToken -> Header
-authTokenHeader (VaultAuthToken token) = ("X-Vault-Token", T.encodeUtf8 token)
 
 -- | <https://www.vaultproject.io/docs/auth/approle.html>
 vaultAppRoleLogin :: VaultAddress -> Manager -> VaultAppRoleId -> VaultAppRoleSecretId -> IO VaultAuthToken
 vaultAppRoleLogin addr manager roleId secretId = do
-    response <- vaultRequestJSON manager "POST" (vaultUrl addr "/auth/approle/login") [] (Just reqBody) [200]
+    response <-
+        runVaultRequest (mkUnauthenticatedVaultConnection addr manager) $
+            newPostRequest "/auth/approle/login" (Just reqBody)
     maybe failOnNullAuth (return . _VaultAuth_ClientToken) $ _VaultAppRoleResponse_Auth response
   where
-  reqBody = object
-      [ "role_id" .= unVaultAppRoleId roleId,
-        "secret_id" .= unVaultAppRoleSecretId secretId
-      ]
-  failOnNullAuth = fail "Auth on login is null"
+    reqBody =
+        object
+            [ "role_id" .= unVaultAppRoleId roleId
+            , "secret_id" .= unVaultAppRoleSecretId secretId
+            ]
+    failOnNullAuth = fail "Auth on login is null"
 
 -- | <https://www.vaultproject.io/docs/auth/approle.html#via-the-api-1>
 vaultAuthEnable :: VaultConnection -> Text -> IO ()
-vaultAuthEnable VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} authMethod = do
-    _ <- vaultRequest _VaultConnection_Manager "POST" (vaultUrl _VaultConnection_VaultAddress "/sys/auth/" ++ T.unpack authMethod) headers (Just reqBody) [200]
+vaultAuthEnable conn authMethod = do
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [200, 204]
+            $ newPostRequest ("/sys/auth/" <> authMethod) (Just reqBody)
     pure ()
   where
-  reqBody = object [ "type" .= authMethod ]
-  headers = [authTokenHeader _VaultConnection_AuthToken]
+    reqBody = object ["type" .= authMethod]
 
 -- | <https://www.vaultproject.io/api/system/policies.html#create-update-acl-policy>
 vaultPolicyCreate :: VaultConnection -> Text -> Text -> IO ()
-vaultPolicyCreate VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} policyName policy = do
-    _ <- vaultRequest _VaultConnection_Manager "PUT" (vaultUrl _VaultConnection_VaultAddress "/sys/policies/acl/" ++ T.unpack policyName) headers (Just reqBody) [200]
+vaultPolicyCreate conn policyName policy = do
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [200, 204]
+            $ newPutRequest
+                ("/sys/policies/acl/" <> policyName)
+                (Just reqBody)
     pure ()
-    where
-    reqBody = object [ "policy" .= policy ]
-    headers = [authTokenHeader _VaultConnection_AuthToken]
+  where
+    reqBody = object ["policy" .= policy]
 
-data VaultAppRoleListResponse = VaultAppRoleListResponse
-    { _VaultAppRoleListResponse_AppRoles :: [Text] }
+newtype VaultAppRoleListResponse = VaultAppRoleListResponse
+    {_VaultAppRoleListResponse_AppRoles :: [Text]}
 
 instance FromJSON VaultAppRoleListResponse where
     parseJSON (Object v) =
-        VaultAppRoleListResponse <$>
-            v .: "keys"
+        VaultAppRoleListResponse
+            <$> v .: "keys"
     parseJSON _ = fail "Not an Object"
 
--- | <https://www.vaultproject.io/api/auth/approle/index.html#create-new-approle>
---
--- Note: For TTL fields, only integer number seconds, i.e. 3600, are supported
+{- | <https://www.vaultproject.io/api/auth/approle/index.html#create-new-approle>
+
+ Note: For TTL fields, only integer number seconds, i.e. 3600, are supported
+-}
 data VaultAppRoleParameters = VaultAppRoleParameters
     { _VaultAppRoleParameters_BindSecretId :: Bool
     , _VaultAppRoleParameters_Policies :: [Text]
@@ -333,32 +297,34 @@ data VaultAppRoleParameters = VaultAppRoleParameters
     }
 
 instance ToJSON VaultAppRoleParameters where
-    toJSON v = object $
-        [ "bind_secret_id" .= _VaultAppRoleParameters_BindSecretId v
-        , "policies" .= _VaultAppRoleParameters_Policies v
-        ] <> catMaybes
-        [ "secret_id_num_uses" .=? _VaultAppRoleParameters_SecretIdNumUses v
-        , "secret_id_ttl" .=? _VaultAppRoleParameters_SecretIdTTL v
-        , "token_num_uses" .=? _VaultAppRoleParameters_TokenNumUses v
-        , "token_ttl" .=? _VaultAppRoleParameters_TokenTTL v
-        , "token_max_ttl" .=? _VaultAppRoleParameters_TokenMaxTTL v
-        , "period" .=? _VaultAppRoleParameters_Period v
-        ]
+    toJSON v =
+        object $
+            [ "bind_secret_id" .= _VaultAppRoleParameters_BindSecretId v
+            , "policies" .= _VaultAppRoleParameters_Policies v
+            ]
+                <> catMaybes
+                    [ "secret_id_num_uses" .=? _VaultAppRoleParameters_SecretIdNumUses v
+                    , "secret_id_ttl" .=? _VaultAppRoleParameters_SecretIdTTL v
+                    , "token_num_uses" .=? _VaultAppRoleParameters_TokenNumUses v
+                    , "token_ttl" .=? _VaultAppRoleParameters_TokenTTL v
+                    , "token_max_ttl" .=? _VaultAppRoleParameters_TokenMaxTTL v
+                    , "period" .=? _VaultAppRoleParameters_Period v
+                    ]
       where
         (.=?) :: ToJSON x => Text -> Maybe x -> Maybe Pair
         t .=? x = (t .=) <$> x
 
 instance FromJSON VaultAppRoleParameters where
     parseJSON (Object v) =
-        VaultAppRoleParameters <$>
-            v .: "bind_secret_id" <*>
-            v .: "policies" <*>
-            v .:? "secret_id_num_uses" <*>
-            v .:? "secret_id_ttl" <*>
-            v .:? "token_num_uses" <*>
-            v .:? "token_ttl" <*>
-            v .:? "token_max_ttl" <*>
-            v .:? "period"
+        VaultAppRoleParameters
+            <$> v .: "bind_secret_id"
+            <*> v .: "policies"
+            <*> v .:? "secret_id_num_uses"
+            <*> v .:? "secret_id_ttl"
+            <*> v .:? "token_num_uses"
+            <*> v .:? "token_ttl"
+            <*> v .:? "token_max_ttl"
+            <*> v .:? "period"
     parseJSON _ = fail "Not an Object"
 
 defaultVaultAppRoleParameters :: VaultAppRoleParameters
@@ -366,22 +332,23 @@ defaultVaultAppRoleParameters = VaultAppRoleParameters True [] Nothing Nothing N
 
 -- | <https://www.vaultproject.io/api/auth/approle/index.html#create-new-approle>
 vaultAppRoleCreate :: VaultConnection -> Text -> VaultAppRoleParameters -> IO ()
-vaultAppRoleCreate VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} appRoleName varp = do
-    _ <- vaultRequest _VaultConnection_Manager "POST" (vaultUrl _VaultConnection_VaultAddress "/auth/approle/role/" ++ T.unpack appRoleName) headers (Just varp) [200]
+vaultAppRoleCreate conn appRoleName varp = do
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [200, 204]
+            $ newPostRequest ("/auth/approle/role/" <> appRoleName) (Just varp)
     pure ()
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
 
 -- | <https://www.vaultproject.io/api/auth/approle/index.html#read-approle-role-id>
 vaultAppRoleRoleIdRead :: VaultConnection -> Text -> IO VaultAppRoleId
-vaultAppRoleRoleIdRead VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} appRoleName = do
-    response <- vaultRequestJSON _VaultConnection_Manager "GET" (vaultUrl _VaultConnection_VaultAddress "/auth/approle/role/" ++ T.unpack appRoleName ++ "/role-id") headers (Nothing :: Maybe ()) [200]
+vaultAppRoleRoleIdRead conn appRoleName = do
+    response <-
+        runVaultRequest conn $
+            newGetRequest ("/auth/approle/role/" <> appRoleName <> "/role-id")
     let d = _VaultAppRoleResponse_Data response
     case parseEither parseJSON d of
-      Left err -> throwIO $ VaultException_ParseBodyError "GET" ("/auth/approle/role/" ++ T.unpack appRoleName ++ "/role-id") (encode d) err
-      Right obj -> return obj
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
+        Left err -> throwIO $ VaultException_ParseBodyError "GET" ("/auth/approle/role/" <> appRoleName <> "/role-id") (encode d) (T.pack err)
+        Right obj -> return obj
 
 data VaultAppRoleSecretIdGenerateResponse = VaultAppRoleSecretIdGenerateResponse
     { _VaultAppRoleSecretIdGenerateResponse_SecretIdAccessor :: VaultAppRoleSecretIdAccessor
@@ -390,33 +357,36 @@ data VaultAppRoleSecretIdGenerateResponse = VaultAppRoleSecretIdGenerateResponse
 
 instance FromJSON VaultAppRoleSecretIdGenerateResponse where
     parseJSON (Object v) =
-        VaultAppRoleSecretIdGenerateResponse <$>
-            v .: "secret_id_accessor" <*>
-            v .: "secret_id"
+        VaultAppRoleSecretIdGenerateResponse
+            <$> v .: "secret_id_accessor"
+            <*> v .: "secret_id"
     parseJSON _ = fail "Not an Object"
 
 -- | <https://www.vaultproject.io/api/auth/approle/index.html#generate-new-secret-id>
 vaultAppRoleSecretIdGenerate :: VaultConnection -> Text -> Text -> IO VaultAppRoleSecretIdGenerateResponse
-vaultAppRoleSecretIdGenerate VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} appRoleName metadata = do
-    response <- vaultRequestJSON _VaultConnection_Manager "POST" (vaultUrl _VaultConnection_VaultAddress "/auth/approle/role/" ++ T.unpack appRoleName ++ "/secret-id") headers (Just reqBody) [200]
+vaultAppRoleSecretIdGenerate conn appRoleName metadata = do
+    response <-
+        runVaultRequest conn $
+            newPostRequest ("/auth/approle/role/" <> appRoleName <> "/secret-id") (Just reqBody)
     let d = _VaultAppRoleResponse_Data response
     case parseEither parseJSON d of
-      Left err -> throwIO $ VaultException_ParseBodyError "POST" ("/auth/approle/role/" ++ T.unpack appRoleName ++ "/secret-id") (encode d) err
-      Right obj -> return obj
-    where
-    reqBody = object[ "metadata" .= metadata ]
-    headers = [authTokenHeader _VaultConnection_AuthToken]
+        Left err -> throwIO $ VaultException_ParseBodyError "POST" ("/auth/approle/role/" <> appRoleName <> "/secret-id") (encode d) (T.pack err)
+        Right obj -> return obj
+  where
+    reqBody = object ["metadata" .= metadata]
 
 vaultSeal :: VaultConnection -> IO ()
-vaultSeal VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} = do
-    _ <- vaultRequest _VaultConnection_Manager "PUT" (vaultUrl _VaultConnection_VaultAddress "/sys/seal") headers (Nothing :: Maybe ()) [200]
+vaultSeal conn = do
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [200, 204]
+            $ newPutRequest "/sys/seal" (Nothing :: Maybe ())
     pure ()
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
 
--- | <https://www.vaultproject.io/docs/http/sys-unseal.html>
---
--- See 'vaultUnseal'
+{- | <https://www.vaultproject.io/docs/http/sys-unseal.html>
+
+ See 'vaultUnseal'
+-}
 data VaultUnseal
     = VaultUnseal_Key VaultUnsealKey
     | VaultUnseal_Reset
@@ -426,42 +396,50 @@ data VaultUnseal
 vaultUnseal :: VaultAddress -> VaultUnseal -> IO VaultSealStatus
 vaultUnseal addr unseal = do
     let reqBody = case unseal of
-            VaultUnseal_Key (VaultUnsealKey key) -> object
-                [ "key" .= key
-                ]
-            VaultUnseal_Reset -> object
-                [ "reset" .= True
-                ]
+            VaultUnseal_Key (VaultUnsealKey key) ->
+                object
+                    [ "key" .= key
+                    ]
+            VaultUnseal_Reset ->
+                object
+                    [ "reset" .= True
+                    ]
     manager <- newManager tlsManagerSettings
-    vaultRequestJSON manager "PUT" (vaultUrl addr "/sys/unseal") [] (Just reqBody) [200]
+    runVaultRequest (mkUnauthenticatedVaultConnection addr manager) $
+        newPutRequest "/sys/unseal" (Just reqBody)
 
-type VaultMountRead = VaultMount Text VaultMountConfigRead
-type VaultMountWrite = VaultMount (Maybe Text) (Maybe VaultMountConfigWrite)
+type VaultMountRead = VaultMount Text VaultMountConfigRead (Maybe VaultMountConfigOptions)
+type VaultMountWrite = VaultMount (Maybe Text) (Maybe VaultMountConfigWrite) (Maybe VaultMountConfigOptions)
 type VaultMountConfigRead = VaultMountConfig Int
 type VaultMountConfigWrite = VaultMountConfig (Maybe Int)
+type VaultMountConfigOptions = VaultMountOptions (Maybe Int)
 
 -- | <https://www.vaultproject.io/docs/http/sys-mounts.html>
-data VaultMount a b = VaultMount
+data VaultMount a b c = VaultMount
     { _VaultMount_Type :: Text
     , _VaultMount_Description :: a
     , _VaultMount_Config :: b
+    , _VaultMount_Options :: c
     }
     deriving (Show, Eq, Ord)
 
 instance FromJSON VaultMountRead where
     parseJSON (Object v) =
-        VaultMount <$>
-             v .: "type" <*>
-             v .: "description" <*>
-             v .: "config"
+        VaultMount
+            <$> v .: "type"
+            <*> v .: "description"
+            <*> v .: "config"
+            <*> v .: "options"
     parseJSON _ = fail "Not an Object"
 
 instance ToJSON VaultMountWrite where
-    toJSON v = object
-        [ "type" .= _VaultMount_Type v
-        , "description" .= _VaultMount_Description v
-        , "config" .= _VaultMount_Config v
-        ]
+    toJSON v =
+        object
+            [ "type" .= _VaultMount_Type v
+            , "description" .= _VaultMount_Description v
+            , "config" .= _VaultMount_Config v
+            , "options" .= _VaultMount_Options v
+            ]
 
 -- | <https://www.vaultproject.io/docs/http/sys-mounts.html>
 data VaultMountConfig a = VaultMountConfig
@@ -472,27 +450,46 @@ data VaultMountConfig a = VaultMountConfig
 
 instance FromJSON VaultMountConfigRead where
     parseJSON (Object v) =
-        VaultMountConfig <$>
-             v .: "default_lease_ttl" <*>
-             v .: "max_lease_ttl"
+        VaultMountConfig
+            <$> v .: "default_lease_ttl"
+            <*> v .: "max_lease_ttl"
     parseJSON _ = fail "Not an Object"
 
 instance ToJSON VaultMountConfigWrite where
-    toJSON v = object
-        [ "default_lease_ttl" .= fmap formatSeconds (_VaultMountConfig_DefaultLeaseTtl v)
-        , "max_lease_ttl" .= fmap formatSeconds (_VaultMountConfig_MaxLeaseTtl v)
-        ]
+    toJSON v =
+        object
+            [ "default_lease_ttl" .= fmap formatSeconds (_VaultMountConfig_DefaultLeaseTtl v)
+            , "max_lease_ttl" .= fmap formatSeconds (_VaultMountConfig_MaxLeaseTtl v)
+            ]
+      where
+        formatSeconds :: Int -> String
+        formatSeconds n = show n ++ "s"
 
-formatSeconds :: Int -> String
-formatSeconds n = show n ++ "s"
+newtype VaultMountOptions a = VaultMountOptions
+    { _VaultMountOptions_Version :: a
+    }
+    deriving (Show, Eq, Ord)
 
--- | <https://www.vaultproject.io/docs/http/sys-mounts.html>
---
--- For your convenience, the results are returned sorted (by the mount point)
+instance FromJSON VaultMountConfigOptions where
+    parseJSON (Object v) =
+        VaultMountOptions
+            <$> (read <$> v .: "version")
+    parseJSON _ = fail "Not an Object"
+
+instance ToJSON VaultMountConfigOptions where
+    toJSON v =
+        object
+            [ "version" .= (show <$> _VaultMountOptions_Version v)
+            ]
+
+{- | <https://www.vaultproject.io/docs/http/sys-mounts.html>
+
+ For your convenience, the results are returned sorted (by the mount point)
+-}
 vaultMounts :: VaultConnection -> IO [(Text, VaultMountRead)]
-vaultMounts VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} = do
-    let reqPath = vaultUrl _VaultConnection_VaultAddress "/sys/mounts"
-    rspObj <- vaultRequestJSON _VaultConnection_Manager "GET" reqPath headers (Nothing :: Maybe ()) [200]
+vaultMounts conn = do
+    let reqPath = "/sys/mounts"
+    rspObj <- runVaultRequest conn $ newGetRequest reqPath
 
     -- Vault 0.6.1 has a different format than previous versions.
     -- See <https://github.com/hashicorp/vault/issues/1965>
@@ -503,169 +500,57 @@ vaultMounts VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Mana
             Just v -> v
 
     case parseEither parseJSON root of
-        Left err -> throwIO $ VaultException_ParseBodyError "GET" reqPath (encode rspObj) err
+        Left err -> throwIO $ VaultException_ParseBodyError "GET" reqPath (encode rspObj) (T.pack err)
         Right obj -> pure $ sortOn fst (H.toList obj)
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
 
 -- | <https://www.vaultproject.io/docs/http/sys-mounts.html>
 vaultMountTune :: VaultConnection -> Text -> IO VaultMountConfigRead
-vaultMountTune VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} mountPoint = do
-    vaultRequestJSON _VaultConnection_Manager "GET" (vaultUrl _VaultConnection_VaultAddress "/sys/mounts/" ++ T.unpack mountPoint ++ "/tune") headers (Nothing :: Maybe ()) [200]
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
+vaultMountTune conn mountPoint =
+    runVaultRequest conn
+        . newGetRequest
+        $ "/sys/mounts/" <> mountPoint <> "/tune"
 
 -- | <https://www.vaultproject.io/docs/http/sys-mounts.html>
 vaultMountSetTune :: VaultConnection -> Text -> VaultMountConfigWrite -> IO ()
-vaultMountSetTune VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} mountPoint mountConfig = do
+vaultMountSetTune conn mountPoint mountConfig = do
     let reqBody = mountConfig
-    _ <- vaultRequest _VaultConnection_Manager "POST" (vaultUrl _VaultConnection_VaultAddress "/sys/mounts/" ++ T.unpack mountPoint ++ "/tune") headers (Just reqBody) [200]
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [200, 204]
+            $ newPostRequest ("/sys/mounts/" <> mountPoint <> "/tune") (Just reqBody)
     pure ()
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
 
 -- | <https://www.vaultproject.io/docs/http/sys-mounts.html>
 vaultNewMount :: VaultConnection -> Text -> VaultMountWrite -> IO ()
-vaultNewMount VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} mountPoint vaultMount = do
+vaultNewMount conn mountPoint vaultMount = do
     let reqBody = vaultMount
-    _ <- vaultRequest _VaultConnection_Manager "POST" (vaultUrl _VaultConnection_VaultAddress "/sys/mounts/" ++ T.unpack mountPoint) headers (Just reqBody) [200]
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [200, 204]
+            $ newPostRequest ("/sys/mounts/" <> mountPoint) (Just reqBody)
     pure ()
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
 
 -- | <https://www.vaultproject.io/docs/http/sys-mounts.html>
 vaultUnmount :: VaultConnection -> Text -> IO ()
-vaultUnmount VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} mountPoint = do
-    _ <- vaultRequest _VaultConnection_Manager "DELETE" (vaultUrl _VaultConnection_VaultAddress "/sys/mounts/" ++ T.unpack mountPoint) headers (Nothing :: Maybe ()) [200]
+vaultUnmount conn mountPoint = do
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [200, 204]
+            . newDeleteRequest
+            $ "/sys/mounts/" <> mountPoint
     pure ()
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
 
 data VaultSecretMetadata = VaultSecretMetadata
     { _VaultSecretMetadata_leaseDuration :: Int
     , _VaultSecretMetadata_leaseId :: Text
     , _VauleSecretMetadata_renewable :: Bool
     }
-    deriving (Show, Eq {- TODO Ord #-})
+    deriving (Show, Eq {- TODO Ord -})
 
 instance FromJSON VaultSecretMetadata where
     parseJSON (Object v) =
-        VaultSecretMetadata <$>
-            v .: "lease_duration" <*>
-            v .: "lease_id" <*>
-            v .: "renewable"
+        VaultSecretMetadata
+            <$> v .: "lease_duration"
+            <*> v .: "lease_id"
+            <*> v .: "renewable"
     parseJSON _ = fail "Not an Object"
-
--- | <https://www.vaultproject.io/docs/secrets/generic/index.html>
---
--- The value that you give must encode as a JSON object
-vaultWrite :: ToJSON a => VaultConnection -> VaultSecretPath -> a -> IO ()
-vaultWrite VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} (VaultSecretPath (mountedPath, searchPath)) value = do
-    let reqBody = value
-    let path = vaultActionUrl Create _VaultConnection_VaultAddress mountedPath searchPath
-    _ <- vaultRequest _VaultConnection_Manager "POST" path headers (Just reqBody) [200, 204]
-    pure ()
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
-
-vaultRead
-    :: FromJSON a
-    => VaultConnection
-    -> VaultSecretPath
-    -> IO (VaultSecretMetadata, Either (Value, String) a) -- ^ A 'Left' result
-                                                          -- means that the
-                                                          -- secret's "data"
-                                                          -- could not be
-                                                          -- parsed into the
-                                                          -- data structure
-                                                          -- that you
-                                                          -- requested.
-                                                          --
-                                                          -- You will get the
-                                                          -- "data" as a raw
-                                                          -- 'Value' as well as
-                                                          -- the error message
-                                                          -- from the parse
-                                                          -- failure
-vaultRead VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} (VaultSecretPath (mountedPath, searchPath)) = do
-    let path = vaultActionUrl ReadMetadata _VaultConnection_VaultAddress mountedPath searchPath
-    rspObj <- vaultRequestJSON _VaultConnection_Manager "GET" path headers (Nothing :: Maybe ()) [200]
-    case parseEither parseJSON (Object rspObj) of
-        Left err -> throwIO $ VaultException_ParseBodyError "GET" path (encode rspObj) err
-        Right metadata -> case parseEither (.: "data") rspObj of
-            Left err -> throwIO $ VaultException_ParseBodyError "GET" path (encode rspObj) err
-            Right dataObj -> case parseEither parseJSON (Object dataObj) of
-                Left err -> pure (metadata, Left (Object dataObj, err))
-                Right data_ -> pure (metadata, Right data_)
-
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
-
--- | <https://www.vaultproject.io/docs/secrets/generic/index.html>
-vaultDelete :: VaultConnection -> VaultSecretPath -> IO ()
-vaultDelete VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} (VaultSecretPath (mountedPath, searchPath)) = do
-    let path = vaultActionUrl DeleteMetadata _VaultConnection_VaultAddress mountedPath searchPath
-    _ <- vaultRequest _VaultConnection_Manager "DELETE" path headers (Nothing :: Maybe ()) [204]
-    pure ()
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
-
-data VaultListResult = VaultListResult [Text]
-
-instance FromJSON VaultListResult where
-    parseJSON (Object v) = do
-        data_ <- v .: "data"
-        keys <- data_ .: "keys"
-        pure (VaultListResult keys)
-    parseJSON _ = fail "Not an Object"
-
--- | <https://www.vaultproject.io/docs/secrets/generic/index.html>
---
--- This will normalise the results to be full secret paths.
---
--- Will return only secrets that in the are located in the folder hierarchy
--- directly below the given folder.
---
--- Use 'isFolder' to check if whether each result is a secret or a subfolder.
---
--- The order of the results is unspecified.
---
--- To recursively retrieve all of the secrets use 'vaultListRecursive'
-vaultList :: VaultConnection -> VaultSecretPath -> IO [VaultSecretPath]
-vaultList VaultConnection{_VaultConnection_VaultAddress, _VaultConnection_Manager, _VaultConnection_AuthToken} (VaultSecretPath (VaultMountedPath mountedPath, VaultSearchPath searchPath)) = do
-    let path = vaultActionUrl ListSecrets _VaultConnection_VaultAddress (VaultMountedPath mountedPath) (VaultSearchPath searchPath)
-    VaultListResult keys <- vaultRequestJSON _VaultConnection_Manager "LIST" path headers (Nothing :: Maybe ()) [200]
-    pure $ map (VaultSecretPath . fullSecretPath) keys
-    where
-    headers = [authTokenHeader _VaultConnection_AuthToken]
-    fullSecretPath key = (VaultMountedPath mountedPath, VaultSearchPath (withTrailingSlash `T.append` key))
-    withTrailingSlash
-        | T.null searchPath = "/"
-        | T.last searchPath == '/' = searchPath
-        | otherwise = searchPath `T.snoc` '/'
-
-
--- | Does the path end with a '/' character?
---
--- Meant to be used on the results of 'vaultList'
-isFolder :: VaultSecretPath -> Bool
-isFolder (VaultSecretPath (_, VaultSearchPath searchPath))
-    | T.null searchPath = False
-    | otherwise = T.last searchPath == '/'
-
--- | Recursively calls 'vaultList' to retrieve all of the secrets in a folder
--- (including all subfolders and sub-subfolders, etc...)
---
--- There will be no folders in the result.
---
--- The order of the results is unspecified.
-vaultListRecursive :: VaultConnection -> VaultSecretPath -> IO [VaultSecretPath]
-vaultListRecursive conn location = do
-    paths <- vaultList conn location
-    (flip concatMapM) paths $ \path -> do
-        if isFolder path
-            then vaultListRecursive conn path
-            else pure [path]
-
-concatMapM        :: (Monad m) => (a -> m [b]) -> [a] -> m [b]
-concatMapM f xs   =  liftM concat (mapM f xs)

--- a/vault-tool/src/Network/VaultTool/Internal.hs
+++ b/vault-tool/src/Network/VaultTool/Internal.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.VaultTool.Internal (
     VaultRequest,
-    runVaultRequest,
-    runVaultRequest_,
+    runVaultRequestAuthenticated,
+    runVaultRequestAuthenticated_,
+    runVaultRequestUnauthenticated,
+    runVaultRequestUnauthenticated_,
     newGetRequest,
     newPostRequest,
     newPutRequest,
@@ -61,12 +64,15 @@ newListRequest path = newRequest "LIST" path Nothing
 withStatusCodes :: [Int] -> VaultRequest a -> VaultRequest a
 withStatusCodes statusCodes req = req{vrExpectedStatuses = statusCodes}
 
-authTokenHeader :: VaultConnection -> RequestHeaders
-authTokenHeader = maybe mempty mkAuthTokenHeader . vaultAuthToken
-  where
-    mkAuthTokenHeader (VaultAuthToken token) = [("X-Vault-Token", T.encodeUtf8 token)]
+vaultConnectionManager :: VaultConnection a -> Manager
+vaultConnectionManager (UnauthenticatedVaultConnection m _) = m
+vaultConnectionManager (AuthenticatedVaultConnection m _ _) = m
 
-vaultRequest :: ToJSON a => VaultConnection -> VaultRequest a -> IO BL.ByteString
+vaultAddress :: VaultConnection a -> VaultAddress
+vaultAddress (UnauthenticatedVaultConnection _ a) = a
+vaultAddress (AuthenticatedVaultConnection _ a _) = a
+
+vaultRequest :: ToJSON a => VaultConnection b -> VaultRequest a -> IO BL.ByteString
 vaultRequest conn VaultRequest{vrMethod, vrPath, vrBody, vrExpectedStatuses} = do
     initReq <- case parseRequest absolutePath of
         Nothing -> throwIO $ VaultException_InvalidAddress vrMethod vrPath
@@ -85,12 +91,30 @@ vaultRequest conn VaultRequest{vrMethod, vrPath, vrBody, vrExpectedStatuses} = d
   where
     absolutePath = T.unpack $ T.intercalate "/" [unVaultAddress (vaultAddress conn), "v1", vrPath]
 
-runVaultRequest :: (FromJSON b, ToJSON a) => VaultConnection -> VaultRequest a -> IO b
+    authTokenHeader :: VaultConnection a -> RequestHeaders
+    authTokenHeader (UnauthenticatedVaultConnection _ _) = mempty
+    authTokenHeader (AuthenticatedVaultConnection _ _ (VaultAuthToken token)) =
+        [("X-Vault-Token", T.encodeUtf8 token)]
+
+runVaultRequestAuthenticated :: (FromJSON b, ToJSON a) => VaultConnection Authenticated -> VaultRequest a -> IO b
+runVaultRequestAuthenticated = runVaultRequest
+
+runVaultRequestUnauthenticated :: (FromJSON b, ToJSON a) => VaultConnection c -> VaultRequest a -> IO b
+runVaultRequestUnauthenticated conn = runVaultRequest (asUnathenticated conn)
+
+runVaultRequest :: (FromJSON b, ToJSON a) => VaultConnection c -> VaultRequest a -> IO b
 runVaultRequest conn req@VaultRequest{vrMethod, vrPath} = do
     rspBody <- vaultRequest conn req
     case eitherDecode' rspBody of
         Left err -> throwIO $ VaultException_ParseBodyError vrMethod vrPath rspBody (T.pack err)
         Right x -> pure x
 
-runVaultRequest_ :: (ToJSON a) => VaultConnection -> VaultRequest a -> IO ()
-runVaultRequest_ conn = void . vaultRequest conn
+runVaultRequestAuthenticated_ :: (ToJSON a) => VaultConnection Authenticated -> VaultRequest a -> IO ()
+runVaultRequestAuthenticated_ conn = void . vaultRequest conn
+
+runVaultRequestUnauthenticated_ :: (ToJSON a) => VaultConnection a -> VaultRequest a -> IO ()
+runVaultRequestUnauthenticated_ conn = void . vaultRequest (asUnathenticated conn)
+
+asUnathenticated :: VaultConnection a -> VaultConnection Unauthenticated
+asUnathenticated conn@(UnauthenticatedVaultConnection _ _) = conn
+asUnathenticated (AuthenticatedVaultConnection m c _) = UnauthenticatedVaultConnection m c

--- a/vault-tool/src/Network/VaultTool/Internal.hs
+++ b/vault-tool/src/Network/VaultTool/Internal.hs
@@ -72,12 +72,11 @@ vaultRequest conn VaultRequest{vrMethod, vrPath, vrBody, vrExpectedStatuses} = d
         Nothing -> throwIO $ VaultException_InvalidAddress vrMethod vrPath
         Just initReq -> pure initReq
     let reqBody = maybe BL.empty encode vrBody
-        req =
-            initReq
-                { method = vrMethod
-                , requestBody = RequestBodyLBS reqBody
-                , requestHeaders = requestHeaders initReq ++ authTokenHeader conn
-                }
+        req = initReq
+            { method = vrMethod
+            , requestBody = RequestBodyLBS reqBody
+            , requestHeaders = requestHeaders initReq ++ authTokenHeader conn
+            }
     rsp <- httpLbs req (vaultConnectionManager conn)
     let s = statusCode (responseStatus rsp)
     unless (s `elem` vrExpectedStatuses) $ do

--- a/vault-tool/src/Network/VaultTool/Internal.hs
+++ b/vault-tool/src/Network/VaultTool/Internal.hs
@@ -24,6 +24,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Network.HTTP.Client
+import Network.HTTP.Types.Header
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 
@@ -63,8 +64,16 @@ newListRequest path = newRequest "LIST" path Nothing
 withStatusCodes :: [Int] -> VaultRequest a -> VaultRequest a
 withStatusCodes statusCodes req = req{vrExpectedStatuses = statusCodes}
 
-vaultRequest :: ToJSON a => Manager -> VaultAddress -> Maybe VaultAuthToken -> VaultRequest a -> IO BL.ByteString
-vaultRequest manager addr mbToken VaultRequest{vrMethod, vrPath, vrBody, vrExpectedStatuses} = do
+vaultConnectionManager :: VaultConnection a -> Manager
+vaultConnectionManager (UnauthenticatedVaultConnection m _) = m
+vaultConnectionManager (AuthenticatedVaultConnection m _ _) = m
+
+vaultAddress :: VaultConnection a -> VaultAddress
+vaultAddress (UnauthenticatedVaultConnection _ a) = a
+vaultAddress (AuthenticatedVaultConnection _ a _) = a
+
+vaultRequest :: ToJSON a => VaultConnection b -> VaultRequest a -> IO BL.ByteString
+vaultRequest conn VaultRequest{vrMethod, vrPath, vrBody, vrExpectedStatuses} = do
     initReq <- case parseRequest absolutePath of
         Nothing -> throwIO $ VaultException_InvalidAddress vrMethod vrPath
         Just initReq -> pure initReq
@@ -72,39 +81,40 @@ vaultRequest manager addr mbToken VaultRequest{vrMethod, vrPath, vrBody, vrExpec
         req = initReq
             { method = vrMethod
             , requestBody = RequestBodyLBS reqBody
-            , requestHeaders = requestHeaders initReq ++ authTokenHeader mbToken
+            , requestHeaders = requestHeaders initReq ++ authTokenHeader conn
             }
-    rsp <- httpLbs req manager
+    rsp <- httpLbs req (vaultConnectionManager conn)
     let s = statusCode (responseStatus rsp)
     unless (s `elem` vrExpectedStatuses) $ do
         throwIO $ VaultException_BadStatusCode vrMethod vrPath reqBody s (responseBody rsp)
     pure (responseBody rsp)
   where
-    absolutePath = T.unpack $ T.intercalate "/" [unVaultAddress addr, "v1", vrPath]
+    absolutePath = T.unpack $ T.intercalate "/" [unVaultAddress (vaultAddress conn), "v1", vrPath]
 
-    authTokenHeader = maybe mempty toHeader
-      where
-        toHeader (VaultAuthToken token) = [("X-Vault-Token", T.encodeUtf8 token)]
+    authTokenHeader :: VaultConnection a -> RequestHeaders
+    authTokenHeader (UnauthenticatedVaultConnection _ _) = mempty
+    authTokenHeader (AuthenticatedVaultConnection _ _ (VaultAuthToken token)) =
+        [("X-Vault-Token", T.encodeUtf8 token)]
 
 runVaultRequestAuthenticated :: (FromJSON b, ToJSON a) => VaultConnection Authenticated -> VaultRequest a -> IO b
-runVaultRequestAuthenticated conn req =
-    runAuthenticatedVaultConnection (\m a t -> runVaultRequest m a (Just t) req) conn
+runVaultRequestAuthenticated = runVaultRequest
 
 runVaultRequestUnauthenticated :: (FromJSON b, ToJSON a) => VaultConnection c -> VaultRequest a -> IO b
-runVaultRequestUnauthenticated conn req =
-    runAnyVaultConnection (\m a -> runVaultRequest m a Nothing req) conn
+runVaultRequestUnauthenticated conn = runVaultRequest (asUnathenticated conn)
 
-runVaultRequest :: (FromJSON b, ToJSON a) => Manager -> VaultAddress -> Maybe VaultAuthToken -> VaultRequest a -> IO b
-runVaultRequest manager addr mbToken req@VaultRequest{vrMethod, vrPath} = do
-    rspBody <- vaultRequest manager addr mbToken req
+runVaultRequest :: (FromJSON b, ToJSON a) => VaultConnection c -> VaultRequest a -> IO b
+runVaultRequest conn req@VaultRequest{vrMethod, vrPath} = do
+    rspBody <- vaultRequest conn req
     case eitherDecode' rspBody of
         Left err -> throwIO $ VaultException_ParseBodyError vrMethod vrPath rspBody (T.pack err)
         Right x -> pure x
 
 runVaultRequestAuthenticated_ :: (ToJSON a) => VaultConnection Authenticated -> VaultRequest a -> IO ()
-runVaultRequestAuthenticated_ conn req =
-    void $ runAuthenticatedVaultConnection (\m a t -> vaultRequest m a (Just t) req) conn
+runVaultRequestAuthenticated_ conn = void . vaultRequest conn
 
 runVaultRequestUnauthenticated_ :: (ToJSON a) => VaultConnection a -> VaultRequest a -> IO ()
-runVaultRequestUnauthenticated_ conn req =
-    void $ runAnyVaultConnection (\m a -> vaultRequest m a Nothing req) conn
+runVaultRequestUnauthenticated_ conn = void . vaultRequest (asUnathenticated conn)
+
+asUnathenticated :: VaultConnection a -> VaultConnection Unauthenticated
+asUnathenticated conn@(UnauthenticatedVaultConnection _ _) = conn
+asUnathenticated (AuthenticatedVaultConnection m c _) = UnauthenticatedVaultConnection m c

--- a/vault-tool/src/Network/VaultTool/Internal.hs
+++ b/vault-tool/src/Network/VaultTool/Internal.hs
@@ -18,17 +18,34 @@ module Network.VaultTool.Internal (
 
 import Control.Exception (throwIO)
 import Control.Monad (unless, void)
-import Data.Aeson
+import Data.Aeson (FromJSON, ToJSON, eitherDecode', encode)
 import qualified Data.ByteString.Lazy as BL
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import Network.HTTP.Client
-import Network.HTTP.Types.Header
-import Network.HTTP.Types.Method
-import Network.HTTP.Types.Status
+import Network.HTTP.Client (
+    Manager,
+    RequestBody (..),
+    httpLbs,
+    method,
+    parseRequest,
+    requestBody,
+    requestHeaders,
+    responseBody,
+    responseStatus,
+ )
+import Network.HTTP.Types.Header (RequestHeaders)
+import Network.HTTP.Types.Method (Method)
+import Network.HTTP.Types.Status (statusCode)
 
-import Network.VaultTool.Types
+import Network.VaultTool.Types (
+    Authenticated,
+    Unauthenticated,
+    VaultAddress (..),
+    VaultAuthToken (..),
+    VaultConnection (..),
+    VaultException (..),
+ )
 
 data VaultRequest a = VaultRequest
     { vrMethod :: Method

--- a/vault-tool/src/Network/VaultTool/Internal.hs
+++ b/vault-tool/src/Network/VaultTool/Internal.hs
@@ -24,7 +24,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Network.HTTP.Client
-import Network.HTTP.Types.Header
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 
@@ -64,16 +63,8 @@ newListRequest path = newRequest "LIST" path Nothing
 withStatusCodes :: [Int] -> VaultRequest a -> VaultRequest a
 withStatusCodes statusCodes req = req{vrExpectedStatuses = statusCodes}
 
-vaultConnectionManager :: VaultConnection a -> Manager
-vaultConnectionManager (UnauthenticatedVaultConnection m _) = m
-vaultConnectionManager (AuthenticatedVaultConnection m _ _) = m
-
-vaultAddress :: VaultConnection a -> VaultAddress
-vaultAddress (UnauthenticatedVaultConnection _ a) = a
-vaultAddress (AuthenticatedVaultConnection _ a _) = a
-
-vaultRequest :: ToJSON a => VaultConnection b -> VaultRequest a -> IO BL.ByteString
-vaultRequest conn VaultRequest{vrMethod, vrPath, vrBody, vrExpectedStatuses} = do
+vaultRequest :: ToJSON a => Manager -> VaultAddress -> Maybe VaultAuthToken -> VaultRequest a -> IO BL.ByteString
+vaultRequest manager addr mbToken VaultRequest{vrMethod, vrPath, vrBody, vrExpectedStatuses} = do
     initReq <- case parseRequest absolutePath of
         Nothing -> throwIO $ VaultException_InvalidAddress vrMethod vrPath
         Just initReq -> pure initReq
@@ -81,40 +72,39 @@ vaultRequest conn VaultRequest{vrMethod, vrPath, vrBody, vrExpectedStatuses} = d
         req = initReq
             { method = vrMethod
             , requestBody = RequestBodyLBS reqBody
-            , requestHeaders = requestHeaders initReq ++ authTokenHeader conn
+            , requestHeaders = requestHeaders initReq ++ authTokenHeader mbToken
             }
-    rsp <- httpLbs req (vaultConnectionManager conn)
+    rsp <- httpLbs req manager
     let s = statusCode (responseStatus rsp)
     unless (s `elem` vrExpectedStatuses) $ do
         throwIO $ VaultException_BadStatusCode vrMethod vrPath reqBody s (responseBody rsp)
     pure (responseBody rsp)
   where
-    absolutePath = T.unpack $ T.intercalate "/" [unVaultAddress (vaultAddress conn), "v1", vrPath]
+    absolutePath = T.unpack $ T.intercalate "/" [unVaultAddress addr, "v1", vrPath]
 
-    authTokenHeader :: VaultConnection a -> RequestHeaders
-    authTokenHeader (UnauthenticatedVaultConnection _ _) = mempty
-    authTokenHeader (AuthenticatedVaultConnection _ _ (VaultAuthToken token)) =
-        [("X-Vault-Token", T.encodeUtf8 token)]
+    authTokenHeader = maybe mempty toHeader
+      where
+        toHeader (VaultAuthToken token) = [("X-Vault-Token", T.encodeUtf8 token)]
 
 runVaultRequestAuthenticated :: (FromJSON b, ToJSON a) => VaultConnection Authenticated -> VaultRequest a -> IO b
-runVaultRequestAuthenticated = runVaultRequest
+runVaultRequestAuthenticated conn req =
+    runAuthenticatedVaultConnection (\m a t -> runVaultRequest m a (Just t) req) conn
 
 runVaultRequestUnauthenticated :: (FromJSON b, ToJSON a) => VaultConnection c -> VaultRequest a -> IO b
-runVaultRequestUnauthenticated conn = runVaultRequest (asUnathenticated conn)
+runVaultRequestUnauthenticated conn req =
+    runAnyVaultConnection (\m a -> runVaultRequest m a Nothing req) conn
 
-runVaultRequest :: (FromJSON b, ToJSON a) => VaultConnection c -> VaultRequest a -> IO b
-runVaultRequest conn req@VaultRequest{vrMethod, vrPath} = do
-    rspBody <- vaultRequest conn req
+runVaultRequest :: (FromJSON b, ToJSON a) => Manager -> VaultAddress -> Maybe VaultAuthToken -> VaultRequest a -> IO b
+runVaultRequest manager addr mbToken req@VaultRequest{vrMethod, vrPath} = do
+    rspBody <- vaultRequest manager addr mbToken req
     case eitherDecode' rspBody of
         Left err -> throwIO $ VaultException_ParseBodyError vrMethod vrPath rspBody (T.pack err)
         Right x -> pure x
 
 runVaultRequestAuthenticated_ :: (ToJSON a) => VaultConnection Authenticated -> VaultRequest a -> IO ()
-runVaultRequestAuthenticated_ conn = void . vaultRequest conn
+runVaultRequestAuthenticated_ conn req =
+    void $ runAuthenticatedVaultConnection (\m a t -> vaultRequest m a (Just t) req) conn
 
 runVaultRequestUnauthenticated_ :: (ToJSON a) => VaultConnection a -> VaultRequest a -> IO ()
-runVaultRequestUnauthenticated_ conn = void . vaultRequest (asUnathenticated conn)
-
-asUnathenticated :: VaultConnection a -> VaultConnection Unauthenticated
-asUnathenticated conn@(UnauthenticatedVaultConnection _ _) = conn
-asUnathenticated (AuthenticatedVaultConnection m c _) = UnauthenticatedVaultConnection m c
+runVaultRequestUnauthenticated_ conn req =
+    void $ runAnyVaultConnection (\m a -> vaultRequest m a Nothing req) conn

--- a/vault-tool/src/Network/VaultTool/KeyValueV2.hs
+++ b/vault-tool/src/Network/VaultTool/KeyValueV2.hs
@@ -1,0 +1,284 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | A library for working with Vault's KeyValue version 2 secrets engine
+
+ Unless otherwise specified, all IO functions in this module may
+ potentially throw 'HttpException' or 'VaultException'
+-}
+module Network.VaultTool.KeyValueV2 (
+    VaultSecretVersion (..),
+    VaultSecretVersionMetadata (..),
+    VaultSecretMetadata (..),
+    vaultWrite,
+    vaultRead,
+    vaultReadVersion,
+    vaultDelete,
+    vaultList,
+    isFolder,
+    vaultListRecursive,
+) where
+
+import Control.Applicative ((<|>))
+import Control.Exception (throwIO)
+import Data.Aeson (
+    FromJSON,
+    ToJSON,
+    Value (..),
+    encode,
+    object,
+    parseJSON,
+    toJSON,
+    withObject,
+    (.:),
+    (.=),
+ )
+import Data.Aeson.Types (parseEither)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Time (UTCTime)
+
+import Network.VaultTool.Internal (
+    newDeleteRequest,
+    newGetRequest,
+    newListRequest,
+    newPostRequest,
+    runVaultRequest,
+    runVaultRequest_,
+    withStatusCodes,
+ )
+import Network.VaultTool.Types (
+    VaultConnection,
+    VaultException (..),
+    VaultMountedPath (..),
+    VaultSearchPath (..),
+    VaultSecretPath (..),
+ )
+
+data VaultSecretMetadata = VaultSecretMetadata
+    { _VaultSecretMetadata_leaseDuration :: Int
+    , _VaultSecretMetadata_leaseId :: Text
+    , _VauleSecretMetadata_renewable :: Bool
+    }
+    deriving (Show, Eq {- TODO Ord -})
+
+instance FromJSON VaultSecretMetadata where
+    parseJSON (Object v) =
+        VaultSecretMetadata
+            <$> v .: "lease_duration"
+            <*> v .: "lease_id"
+            <*> v .: "renewable"
+    parseJSON _ = fail "Not an Object"
+
+data VaultSecretVersion a = VaultSecretVersion
+    { vsvData :: a
+    , vsvMetadata :: VaultSecretVersionMetadata
+    }
+    deriving (Show)
+
+instance FromJSON a => FromJSON (VaultSecretVersion a) where
+    parseJSON = withObject "VaultSecretVersion" $ \v ->
+        VaultSecretVersion
+            <$> v .: "data"
+            <*> v .: "metadata"
+
+data VaultSecretVersionMetadata = VaultSecretVersionMetadata
+    { vsvmCreatedTime :: UTCTime
+    , vsvmDeletionTime :: Maybe UTCTime
+    , vsvmDestroyed :: Bool
+    , vsvmVersion :: Int
+    }
+    deriving (Show)
+
+instance FromJSON VaultSecretVersionMetadata where
+    parseJSON = withObject "VaultSecretVersionMetadata" $ \v ->
+        VaultSecretVersionMetadata
+            <$> v .: "created_time"
+            <*> (v .: "deletion_time" >>= parseOptionalDate)
+            <*> v .: "destroyed"
+            <*> v .: "version"
+      where
+        parseOptionalDate x = parseJSON x <|> pure Nothing
+
+vaultRead ::
+    FromJSON a =>
+    VaultConnection ->
+    VaultSecretPath ->
+    -- | A 'Left' result
+    -- means that the
+    -- secret's "data"
+    -- could not be
+    -- parsed into the
+    -- data structure
+    -- that you
+    -- requested.
+    --
+    -- You will get the
+    -- "data" as a raw
+    -- 'Value' as well as
+    -- the error message
+    -- from the parse
+    -- failure
+    IO (VaultSecretMetadata, Either (Value, String) (VaultSecretVersion a))
+vaultRead conn path = vaultReadVersion conn path Nothing
+
+vaultReadVersion ::
+    FromJSON a =>
+    VaultConnection ->
+    VaultSecretPath ->
+    Maybe Int ->
+    -- | A 'Left' result
+    -- means that the
+    -- secret's "data"
+    -- could not be
+    -- parsed into the
+    -- data structure
+    -- that you
+    -- requested.
+    --
+    -- You will get the
+    -- "data" as a raw
+    -- 'Value' as well as
+    -- the error message
+    -- from the parse
+    -- failure
+    IO (VaultSecretMetadata, Either (Value, String) (VaultSecretVersion a))
+vaultReadVersion conn (VaultSecretPath (mountedPath, searchPath)) version = do
+    let path = vaultActionPath ReadSecretVersion mountedPath searchPath <> queryParams
+    rspObj <-
+        runVaultRequest conn $
+            newGetRequest path
+    case parseEither parseJSON (Object rspObj) of
+        Left err -> throwIO $ VaultException_ParseBodyError "GET" path (encode rspObj) (T.pack err)
+        Right metadata -> case parseEither (.: "data") rspObj of
+            Left err -> throwIO $ VaultException_ParseBodyError "GET" path (encode rspObj) (T.pack err)
+            Right dataObj -> case parseEither parseJSON (Object dataObj) of
+                Left err -> pure (metadata, Left (Object dataObj, err))
+                Right data_ -> pure (metadata, Right data_)
+  where
+    queryParams = case version of
+        Nothing -> ""
+        Just n -> "?version=" <> T.pack (show n)
+
+newtype DataWrapper a = DataWrapper a
+
+instance ToJSON a => ToJSON (DataWrapper a) where
+    toJSON (DataWrapper x) = object ["data" .= x]
+
+{- | <https://www.vaultproject.io/docs/secrets/generic/index.html>
+
+ The value that you give must encode as a JSON object
+-}
+vaultWrite :: ToJSON a => VaultConnection -> VaultSecretPath -> a -> IO ()
+vaultWrite conn (VaultSecretPath (mountedPath, searchPath)) value = do
+    let reqBody = value
+    let path = vaultActionPath WriteSecret mountedPath searchPath
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [200, 204]
+            $ newPostRequest path (Just $ DataWrapper reqBody)
+    pure ()
+
+newtype VaultListResult = VaultListResult [Text]
+
+instance FromJSON VaultListResult where
+    parseJSON (Object v) = do
+        data_ <- v .: "data"
+        keys <- data_ .: "keys"
+        pure (VaultListResult keys)
+    parseJSON _ = fail "Not an Object"
+
+{- | <https://www.vaultproject.io/docs/secrets/generic/index.html>
+
+ This will normalise the results to be full secret paths.
+
+ Will return only secrets that in the are located in the folder hierarchy
+ directly below the given folder.
+
+ Use 'isFolder' to check if whether each result is a secret or a subfolder.
+
+ The order of the results is unspecified.
+
+ To recursively retrieve all of the secrets use 'vaultListRecursive'
+-}
+vaultList :: VaultConnection -> VaultSecretPath -> IO [VaultSecretPath]
+vaultList conn (VaultSecretPath (VaultMountedPath mountedPath, VaultSearchPath searchPath)) = do
+    let path = vaultActionPath ListSecrets (VaultMountedPath mountedPath) (VaultSearchPath searchPath)
+    VaultListResult keys <-
+        runVaultRequest conn $
+            newListRequest path
+    pure $ map (VaultSecretPath . fullSecretPath) keys
+  where
+    fullSecretPath key = (VaultMountedPath mountedPath, VaultSearchPath (withTrailingSlash `T.append` key))
+    withTrailingSlash
+        | T.null searchPath = ""
+        | T.last searchPath == '/' = searchPath
+        | otherwise = searchPath `T.snoc` '/'
+
+{- | Recursively calls 'vaultList' to retrieve all of the secrets in a folder
+ (including all subfolders and sub-subfolders, etc...)
+
+ There will be no folders in the result.
+
+ The order of the results is unspecified.
+-}
+vaultListRecursive :: VaultConnection -> VaultSecretPath -> IO [VaultSecretPath]
+vaultListRecursive conn location = do
+    paths <- vaultList conn location
+    flip concatMapM paths $ \path -> do
+        if isFolder path
+            then vaultListRecursive conn path
+            else pure [path]
+  where
+    concatMapM f xs = fmap concat (mapM f xs)
+
+{- | Does the path end with a '/' character?
+
+ Meant to be used on the results of 'vaultList'
+-}
+isFolder :: VaultSecretPath -> Bool
+isFolder (VaultSecretPath (_, VaultSearchPath searchPath))
+    | T.null searchPath = False
+    | otherwise = T.last searchPath == '/'
+
+-- | <https://www.vaultproject.io/docs/secrets/generic/index.html>
+vaultDelete :: VaultConnection -> VaultSecretPath -> IO ()
+vaultDelete conn (VaultSecretPath (mountedPath, searchPath)) = do
+    let path = vaultActionPath HardDeleteSecret mountedPath searchPath
+    _ <-
+        runVaultRequest_ conn
+            . withStatusCodes [204]
+            $ newDeleteRequest path
+    pure ()
+
+data VaultAction
+    = WriteConfig
+    | ReadConfig
+    | ReadSecretVersion
+    | WriteSecret
+    | SoftDeleteLatestSecret
+    | SoftDeleteSecretVersions
+    | UndeleteSecretVersions
+    | DestroySecretVersions
+    | ListSecrets
+    | ReadSecretMetadata
+    | WriteSecreteMetadata
+    | HardDeleteSecret
+
+vaultActionPath :: VaultAction -> VaultMountedPath -> VaultSearchPath -> Text
+vaultActionPath action (VaultMountedPath mountedPath) (VaultSearchPath searchPath) =
+    T.intercalate "/" [mountedPath, actionPrefix action, searchPath]
+  where
+    actionPrefix = \case
+        WriteConfig -> "config"
+        ReadConfig -> "config"
+        ReadSecretVersion -> "data"
+        WriteSecret -> "data"
+        SoftDeleteLatestSecret -> "data"
+        SoftDeleteSecretVersions -> "delete"
+        UndeleteSecretVersions -> "undelete"
+        DestroySecretVersions -> "destroy"
+        ListSecrets -> "metadata"
+        ReadSecretMetadata -> "metadata"
+        WriteSecreteMetadata -> "metadata"
+        HardDeleteSecret -> "metadata"

--- a/vault-tool/src/Network/VaultTool/Types.hs
+++ b/vault-tool/src/Network/VaultTool/Types.hs
@@ -7,13 +7,11 @@ module Network.VaultTool.Types (
     VaultAppRoleSecretId (..),
     VaultAppRoleSecretIdAccessor (..),
     VaultAuthToken (..),
-    VaultConnection,
+    VaultConnection (..),
     Authenticated,
     Unauthenticated,
     authenticatedVaultConnection,
     unauthenticatedVaultConnection,
-    runAnyVaultConnection,
-    runAuthenticatedVaultConnection,
     VaultException (..),
     VaultMountedPath (..),
     VaultSearchPath (..),
@@ -46,13 +44,6 @@ authenticatedVaultConnection = AuthenticatedVaultConnection
 
 unauthenticatedVaultConnection :: Manager -> VaultAddress -> VaultConnection Unauthenticated
 unauthenticatedVaultConnection = UnauthenticatedVaultConnection
-
-runAnyVaultConnection :: (Manager -> VaultAddress -> b) -> VaultConnection a -> b
-runAnyVaultConnection f (UnauthenticatedVaultConnection manager addr) = f manager addr
-runAnyVaultConnection f (AuthenticatedVaultConnection manager addr _) = f manager addr
-
-runAuthenticatedVaultConnection :: (Manager -> VaultAddress -> VaultAuthToken -> a) -> VaultConnection Authenticated -> a
-runAuthenticatedVaultConnection f (AuthenticatedVaultConnection manager addr token) = f manager addr token
 
 newtype VaultAddress = VaultAddress { unVaultAddress :: Text }
     deriving (Show, Eq, Ord)

--- a/vault-tool/src/Network/VaultTool/Types.hs
+++ b/vault-tool/src/Network/VaultTool/Types.hs
@@ -75,8 +75,8 @@ newtype VaultAppRoleId = VaultAppRoleId { unVaultAppRoleId :: Text }
     deriving (Show, Eq, Ord)
 
 instance FromJSON VaultAppRoleId where
-    parseJSON (Object v) = VaultAppRoleId <$> v .: "role_id"
-    parseJSON _ = fail "Not an Object"
+    parseJSON = withObject "VaultAppRoleId" $ \v ->
+        VaultAppRoleId <$> v .: "role_id"
 
 instance ToJSON VaultAppRoleId where
     toJSON v = object [ "role_id" .= unVaultAppRoleId v ]

--- a/vault-tool/src/Network/VaultTool/Types.hs
+++ b/vault-tool/src/Network/VaultTool/Types.hs
@@ -22,8 +22,8 @@ module Network.VaultTool.Types (
 import Control.Exception (Exception)
 import Data.Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as BL
 import Data.Text (Text)
+import qualified Data.ByteString.Lazy as BL
 import Network.HTTP.Client (Manager)
 
 data VaultConnection
@@ -48,13 +48,13 @@ vaultAuthToken :: VaultConnection -> Maybe VaultAuthToken
 vaultAuthToken (AuthenticatedVaultConnection _ _ token) = Just token
 vaultAuthToken (UnauthenticatedVaultConnection _ _) = Nothing
 
-newtype VaultAddress = VaultAddress {unVaultAddress :: Text}
+newtype VaultAddress = VaultAddress { unVaultAddress :: Text }
     deriving (Show, Eq, Ord)
 
-newtype VaultUnsealKey = VaultUnsealKey {unVaultUnsealKey :: Text}
+newtype VaultUnsealKey = VaultUnsealKey { unVaultUnsealKey :: Text }
     deriving (Show, Eq, Ord)
 
-newtype VaultAuthToken = VaultAuthToken {unVaultAuthToken :: Text}
+newtype VaultAuthToken = VaultAuthToken { unVaultAuthToken :: Text }
     deriving (Show, Eq, Ord)
 
 instance FromJSON VaultAuthToken where
@@ -62,16 +62,16 @@ instance FromJSON VaultAuthToken where
         text <- parseJSON j
         pure (VaultAuthToken text)
 
-newtype VaultMountedPath = VaultMountedPath {unVaultMountedPath :: Text}
+newtype VaultMountedPath = VaultMountedPath { unVaultMountedPath :: Text }
     deriving (Show, Eq, Ord)
 
-newtype VaultSearchPath = VaultSearchPath {unVaultSearchPath :: Text}
+newtype VaultSearchPath = VaultSearchPath { unVaultSearchPath :: Text }
     deriving (Show, Eq, Ord)
 
 newtype VaultSecretPath = VaultSecretPath (VaultMountedPath, VaultSearchPath)
     deriving (Show, Eq, Ord)
 
-newtype VaultAppRoleId = VaultAppRoleId {unVaultAppRoleId :: Text}
+newtype VaultAppRoleId = VaultAppRoleId { unVaultAppRoleId :: Text }
     deriving (Show, Eq, Ord)
 
 instance FromJSON VaultAppRoleId where
@@ -79,9 +79,9 @@ instance FromJSON VaultAppRoleId where
     parseJSON _ = fail "Not an Object"
 
 instance ToJSON VaultAppRoleId where
-    toJSON v = object ["role_id" .= unVaultAppRoleId v]
+    toJSON v = object [ "role_id" .= unVaultAppRoleId v ]
 
-newtype VaultAppRoleSecretId = VaultAppRoleSecretId {unVaultAppRoleSecretId :: Text}
+newtype VaultAppRoleSecretId = VaultAppRoleSecretId { unVaultAppRoleSecretId :: Text }
     deriving (Show, Eq, Ord)
 
 instance FromJSON VaultAppRoleSecretId where
@@ -90,9 +90,9 @@ instance FromJSON VaultAppRoleSecretId where
         pure $ VaultAppRoleSecretId text
 
 instance ToJSON VaultAppRoleSecretId where
-    toJSON v = object ["secret_id" .= unVaultAppRoleSecretId v]
+    toJSON v = object [ "secret_id" .= unVaultAppRoleSecretId v ]
 
-newtype VaultAppRoleSecretIdAccessor = VaultAppRoleSecretIdAccessor {unVaultAppRoleSecretIdAccessor :: Text}
+newtype VaultAppRoleSecretIdAccessor = VaultAppRoleSecretIdAccessor { unVaultAppRoleSecretIdAccessor :: Text }
     deriving (Show, Eq, Ord)
 
 instance FromJSON VaultAppRoleSecretIdAccessor where
@@ -101,7 +101,7 @@ instance FromJSON VaultAppRoleSecretIdAccessor where
         pure $ VaultAppRoleSecretIdAccessor text
 
 instance ToJSON VaultAppRoleSecretIdAccessor where
-    toJSON v = object ["secret_id_accessor" .= unVaultAppRoleSecretIdAccessor v]
+    toJSON v = object [ "secret_id_accessor" .= unVaultAppRoleSecretIdAccessor v ]
 
 data VaultException
     = VaultException

--- a/vault-tool/src/Network/VaultTool/Types.hs
+++ b/vault-tool/src/Network/VaultTool/Types.hs
@@ -20,23 +20,23 @@ module Network.VaultTool.Types (
 ) where
 
 import Control.Exception (Exception)
-import Data.Aeson
+import Data.Aeson (FromJSON, ToJSON, (.:), (.=), object, parseJSON, toJSON, withObject)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
 import qualified Data.ByteString.Lazy as BL
 import Network.HTTP.Client (Manager)
 
--- |The APIs exported by this library expect a 'VaultConnection' which is used to know where a vault server is and how
+-- | The APIs exported by this library expect a 'VaultConnection' which is used to know where a vault server is and how
 -- to talk to it. The type parameter is used to distinguish between 'Unauthenticated' and 'Authenticated' requests. When
 -- a function takes a polymorphic connection (VaultConnection a), either type of connection can be used.
 data VaultConnection a where
     UnauthenticatedVaultConnection :: Manager -> VaultAddress -> VaultConnection Unauthenticated
     AuthenticatedVaultConnection :: Manager -> VaultAddress -> VaultAuthToken -> VaultConnection Authenticated
 
--- |Used as a type argument when constructing a 'VaultConnection'. Designates an unauthenticated connection.
+-- | Used as a type argument when constructing a 'VaultConnection'. Designates an unauthenticated connection.
 data Unauthenticated
 
--- |Used as a type argument when constructing a 'VaultConnection'. Designates an authenticated connection.
+-- | Used as a type argument when constructing a 'VaultConnection'. Designates an authenticated connection.
 data Authenticated
 
 authenticatedVaultConnection :: Manager -> VaultAddress -> VaultAuthToken -> VaultConnection Authenticated

--- a/vault-tool/src/Network/VaultTool/Types.hs
+++ b/vault-tool/src/Network/VaultTool/Types.hs
@@ -22,7 +22,13 @@ instance FromJSON VaultAuthToken where
         text <- parseJSON j
         pure (VaultAuthToken text)
 
-newtype VaultSecretPath = VaultSecretPath { unVaultSecretPath :: Text }
+newtype VaultMountedPath = VaultMountedPath { unVaultMountedPath :: Text }
+    deriving (Show, Eq, Ord)
+
+newtype VaultSearchPath = VaultSearchPath { unVaultSearchPath :: Text }
+    deriving (Show, Eq, Ord)
+
+newtype VaultSecretPath = VaultSecretPath (VaultMountedPath, VaultSearchPath)
     deriving (Show, Eq, Ord)
 
 newtype VaultAppRoleId = VaultAppRoleId { unVaultAppRoleId :: Text }

--- a/vault-tool/vault-tool.cabal
+++ b/vault-tool/vault-tool.cabal
@@ -1,5 +1,5 @@
 name:                vault-tool
-version:             0.1.0.1
+version:             0.2.0.0
 synopsis:            Client library for HashiCorp's Vault tool (via HTTP API)
 description:         Client library for HashiCorp's Vault tool (via HTTP API)
 license:             MIT

--- a/vault-tool/vault-tool.cabal
+++ b/vault-tool/vault-tool.cabal
@@ -19,7 +19,8 @@ source-repository head
   location: https://github.com/bitc/hs-vault-tool.git
 
 library
-  exposed-modules:     Network.VaultTool
+  exposed-modules:     Network.VaultTool,
+                       Network.VaultTool.KeyValueV2
 
   other-modules:       Network.VaultTool.Internal,
                        Network.VaultTool.Types
@@ -31,7 +32,8 @@ library
                        http-types,
                        http-client-tls,
                        aeson,
-                       unordered-containers
+                       unordered-containers,
+                       time
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/vault-tool/vault-tool.cabal
+++ b/vault-tool/vault-tool.cabal
@@ -1,5 +1,5 @@
 name:                vault-tool
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Client library for HashiCorp's Vault tool (via HTTP API)
 description:         Client library for HashiCorp's Vault tool (via HTTP API)
 license:             MIT


### PR DESCRIPTION
The original implementation of this vault library was based on Vault's KeyValue v1 secret engine. A few changes were made in an attempt to add support for KeyValue v2 which broke some things and makes some assumptions that make it difficult to work with other Vault secret engines (e.g. TOTP). I have done a major refactor to fix the broken parts and abstract out the pieces specific to KeyValue so we can now start adding other secret engines.

The original refactor was done in https://github.com/viking66/hs-vault-tool/pull/1 on my personal fork of hs-vault-tool. This PR pulls in these changes to the Bitnomial fork.

Tested via unit tests: `stack test`