### PR TITLE
Updated for new aeson, updated stack resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.30
+resolver: lts-23.3
 flags: {}
 packages:
   - vault-tool

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 795b7a893148a42f09956611a0fa1139293fe6ef934d053468d8e53e3e013390
-    size: 719577
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/30.yaml
-  original: lts-22.30
+    sha256: dd89d2322cb5af74c6ab9d96c0c5f6c8e6653e0c991d619b4bb141a49cb98668
+    size: 679282
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/3.yaml
+  original: lts-23.3

--- a/vault-tool-server/vault-tool-server.cabal
+++ b/vault-tool-server/vault-tool-server.cabal
@@ -1,5 +1,5 @@
 name:                vault-tool-server
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            Utility library for spawning a HashiCorp Vault process
 description:         Utility library for spawning a HashiCorp Vault process
 license:             MIT

--- a/vault-tool/src/Data/Aeson/Utils.hs
+++ b/vault-tool/src/Data/Aeson/Utils.hs
@@ -15,10 +15,10 @@ import Data.Maybe (catMaybes)
 object :: [Maybe Pair] -> Value
 object = Aeson.object . catMaybes
 
-(.=!) :: (KeyValue a, ToJSON b) => Key -> b -> Maybe a
+(.=!) :: (KeyValue e a, ToJSON b) => Key -> b -> Maybe a
 k .=! v = Just $ k .= v
 
-(.=?) :: (Functor f, KeyValue a, ToJSON b) => Key -> f b -> f a
+(.=?) :: (Functor f, KeyValue e a, ToJSON b) => Key -> f b -> f a
 k .=? v = (k .=) <$> v
 
 newtype DataWrapper a = DataWrapper {unDataWrapper :: a}

--- a/vault-tool/vault-tool.cabal
+++ b/vault-tool/vault-tool.cabal
@@ -1,5 +1,5 @@
 name:                vault-tool
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            Client library for HashiCorp's Vault tool (via HTTP API)
 description:         Client library for HashiCorp's Vault tool (via HTTP API)
 license:             MIT
@@ -33,8 +33,7 @@ library
                        http-client,
                        http-types,
                        http-client-tls,
-                       -- vault-tool doesn't yet work with new KeyValue constraint from aeson-2.2
-                       aeson < 2.2,
+                       aeson >=2.2,
                        unordered-containers,
                        time
 


### PR DESCRIPTION
This PR updates this repo to build with the newest stackage LTS and associated GHC. The only change needed was an update to a typeclass from Aeson.
